### PR TITLE
Implement action search

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ gio_unix = dependency('gio-unix-2.0')
 glib = dependency('glib-2.0',
   version: '>= 2.44'
 )
+gmodule_export = dependency('gmodule-export-2.0')
 gtk4 = dependency('gtk4',
   version: '>= 4.14.0',
 )

--- a/src/jogg-application.h
+++ b/src/jogg-application.h
@@ -16,6 +16,9 @@ G_DECLARE_FINAL_TYPE (JoggApplication, jogg_application,
                       JOGG, APPLICATION,
                       GtkApplication);
 
+GPtrArray *jogg_application_app_info_search ( JoggApplication *self
+                                            , const char      *query);
+
 JoggApplication *jogg_application_new (void);
 
 G_END_DECLS

--- a/src/jogg-enum-types.c.template
+++ b/src/jogg-enum-types.c.template
@@ -1,0 +1,26 @@
+/*** BEGIN file-header ***/
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
+ */
+
+#include "jogg-enum-types.h"
+/*** END file-header ***/
+
+/*** BEGIN file-production ***/
+
+/* Enumerations from "@basename@" */
+#include "@basename@"
+/*** END file-production ***/
+
+/*** BEGIN value-header ***/
+G_DEFINE_ENUM_TYPE ( @EnumName@
+                   , @enum_name@
+/*** END value-header ***/
+/*** BEGIN value-production ***/
+                   , G_DEFINE_ENUM_VALUE (@VALUENAME@, "@valuenick@")
+/*** END value-production ***/
+/*** BEGIN value-tail ***/
+                   );
+/*** END value-tail ***/

--- a/src/jogg-enum-types.h.template
+++ b/src/jogg-enum-types.h.template
@@ -1,0 +1,30 @@
+/*** BEGIN file-header ***/
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+/*** END file-header ***/
+
+/*** BEGIN file-production ***/
+
+/* Enumerations from "@basename@" */
+
+/*** END file-production ***/
+
+/*** BEGIN enumeration-production ***/
+#define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
+GType @enum_name@_get_type (void);
+
+/*** END enumeration-production ***/
+
+/*** BEGIN file-tail ***/
+
+G_END_DECLS
+/*** END file-tail ***/

--- a/src/jogg-enums.h
+++ b/src/jogg-enums.h
@@ -1,0 +1,23 @@
+#pragma once
+
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
+ */
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+typedef enum
+{
+    JOGG_MATCH_TYPE_INVALID,
+    JOGG_MATCH_TYPE_NAME,
+    JOGG_MATCH_TYPE_GENERIC_NAME,
+    JOGG_MATCH_TYPE_ACTIONS,
+    JOGG_MATCH_TYPE_KEYWORDS,
+    JOGG_MATCH_TYPE_EXEC,
+} JoggMatchType;
+
+G_END_DECLS

--- a/src/jogg-result.c
+++ b/src/jogg-result.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
  */
 
+#include "jogg-enum-types.h"
 #include "jogg-result.h"
 
 struct _JoggResult
@@ -11,24 +12,55 @@ struct _JoggResult
     GObject parent_instance;
 
     GDesktopAppInfo *app_info;
+    char *action;
+    JoggMatchType match_type;
+    bool prefix_match;
 };
 
-enum
-{
-    PROP_APP_INFO = 1,
-    PROP_ICON,
-    PROP_LABEL,
-    N_PROPERTIES,
-};
+enum { PROP_APP_INFO = 1
+     , PROP_ACTION
+     , PROP_MATCH_TYPE
+     , PROP_PREFIX_MATCH
+     , PROP_HIDDEN
+     , PROP_ICON
+     , PROP_LABEL
+     , N_PROPERTIES
+     };
 
 static GParamSpec *properties[N_PROPERTIES];
 
 G_DEFINE_TYPE (JoggResult, jogg_result, G_TYPE_OBJECT);
 
+gboolean
+jogg_result_is_action_visible (GObject    *object,
+                               JoggResult *self)
+{
+    JoggMatchType match_type;
+
+    if (NULL == self)
+    {
+        return FALSE;
+    }
+
+    match_type = jogg_result_get_match_type (self);
+
+    return match_type == JOGG_MATCH_TYPE_ACTIONS;
+}
+
 static void
 jogg_result_init (JoggResult *self)
 {
     (void) self;
+}
+
+static void
+jogg_result_finalize (GObject *object)
+{
+    JoggResult *self = NULL;
+
+    self = JOGG_RESULT (object);
+
+    g_free (g_steal_pointer (&self->action));
 }
 
 static void
@@ -38,6 +70,7 @@ jogg_result_get_property ( GObject    *object
                          , GParamSpec *pspec)
 {
     JoggResult *self = NULL;
+    gboolean nodisplay = false;
     GIcon *icon = NULL;
     const char *name = NULL;
 
@@ -47,6 +80,20 @@ jogg_result_get_property ( GObject    *object
     {
     case PROP_APP_INFO:
         g_value_set_object (value, self->app_info);
+        break;
+    case PROP_ACTION:
+        g_value_set_string (value, self->action);
+        break;
+    case PROP_MATCH_TYPE:
+        g_value_set_enum (value, self->match_type);
+        break;
+    case PROP_PREFIX_MATCH:
+        g_value_set_boolean (value, self->prefix_match);
+        break;
+    case PROP_HIDDEN:
+        nodisplay = g_desktop_app_info_get_nodisplay (self->app_info);
+
+        g_value_set_boolean (value, nodisplay);
         break;
     case PROP_ICON:
         icon = g_app_info_get_icon (G_APP_INFO (self->app_info));
@@ -79,6 +126,15 @@ jogg_result_set_property ( GObject      *object
     case PROP_APP_INFO:
         self->app_info = g_value_get_object (value);
         break;
+    case PROP_ACTION:
+        self->action = g_value_dup_string (value);
+        break;
+    case PROP_MATCH_TYPE:
+        self->match_type = g_value_get_enum (value);
+        break;
+    case PROP_PREFIX_MATCH:
+        self->prefix_match = g_value_get_boolean (value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
         break;
@@ -101,6 +157,42 @@ jogg_result_class_init (JoggResultClass *klass)
                                                       | G_PARAM_STATIC_STRINGS
                                                       )
                                                     );
+    properties[PROP_ACTION] = g_param_spec_string ( "action"
+                                                  , NULL
+                                                  , NULL
+                                                  , NULL
+                                                  , ( G_PARAM_READWRITE
+                                                    | G_PARAM_CONSTRUCT_ONLY
+                                                    | G_PARAM_STATIC_STRINGS
+                                                    )
+                                                  );
+    properties[PROP_MATCH_TYPE] = g_param_spec_enum ( "match-type"
+                                                    , NULL
+                                                    , NULL
+                                                    , JOGG_TYPE_MATCH_TYPE
+                                                    , JOGG_MATCH_TYPE_INVALID
+                                                    , ( G_PARAM_READWRITE
+                                                      | G_PARAM_CONSTRUCT_ONLY
+                                                      | G_PARAM_STATIC_STRINGS
+                                                      )
+                                                    );
+    properties[PROP_PREFIX_MATCH] = g_param_spec_boolean ( "prefix-match"
+                                                         , NULL
+                                                         , NULL
+                                                         , FALSE
+                                                         , ( G_PARAM_READWRITE
+                                                           | G_PARAM_CONSTRUCT_ONLY
+                                                           | G_PARAM_STATIC_STRINGS
+                                                           )
+                                                         );
+    properties[PROP_HIDDEN] = g_param_spec_boolean ( "hidden"
+                                                   , NULL
+                                                   , NULL
+                                                   , FALSE
+                                                   , ( G_PARAM_READABLE
+                                                     | G_PARAM_STATIC_STRINGS
+                                                     )
+                                                   );
     properties[PROP_ICON] = g_param_spec_object ( "icon"
                                                 , NULL
                                                 , NULL
@@ -118,6 +210,7 @@ jogg_result_class_init (JoggResultClass *klass)
                                                    )
                                                  );
 
+    object_class->finalize = jogg_result_finalize;
     object_class->get_property = jogg_result_get_property;
     object_class->set_property = jogg_result_set_property;
 
@@ -135,13 +228,51 @@ jogg_result_get_app_info (JoggResult *self)
     return g_object_ref (self->app_info);
 }
 
+bool
+jogg_result_is_prefix_match (JoggResult *self)
+{
+    g_return_val_if_fail (JOGG_IS_RESULT (self), false);
+
+    return self->prefix_match;
+}
+
+JoggMatchType
+jogg_result_get_match_type (JoggResult *self)
+{
+    g_return_val_if_fail (JOGG_IS_RESULT (self), JOGG_MATCH_TYPE_INVALID);
+
+    return self->match_type;
+}
+
+GtkOrdering
+jogg_result_compare ( const JoggResult *lhs
+                    , const JoggResult *rhs)
+{
+    if (lhs->match_type < rhs->match_type)
+    {
+        return GTK_ORDERING_SMALLER;
+    }
+    else if (lhs->match_type > rhs->match_type)
+    {
+        return GTK_ORDERING_LARGER;
+    }
+
+    return GTK_ORDERING_EQUAL;
+}
+
 JoggResult *
-jogg_result_new (GDesktopAppInfo *app_info)
+jogg_result_new ( GDesktopAppInfo *app_info
+                , const char      *action
+                , JoggMatchType    match_type
+                , bool             prefix_match)
 {
     g_return_val_if_fail (app_info != NULL, NULL);
 
     return g_object_new ( JOGG_TYPE_RESULT
+                        , "action", action
                         , "app-info", app_info
+                        , "match-type", match_type
+                        , "prefix-match", prefix_match
                         , NULL
                         );
 }

--- a/src/jogg-result.h
+++ b/src/jogg-result.h
@@ -6,10 +6,13 @@
 
 #pragma once
 
+#include "jogg-enums.h"
 #include "jogg-types.h"
 
 #include <gio/gio.h>
 #include <gio/gdesktopappinfo.h>
+#include <gtk/gtk.h>
+#include <stdbool.h>
 
 G_BEGIN_DECLS
 
@@ -20,8 +23,16 @@ G_DECLARE_FINAL_TYPE ( JoggResult
                      , GObject
                      );
 
-GDesktopAppInfo *jogg_result_get_app_info (JoggResult *);
+GDesktopAppInfo *jogg_result_get_app_info    (JoggResult *self);
+bool             jogg_result_is_prefix_match (JoggResult *self);
+JoggMatchType    jogg_result_get_match_type  (JoggResult *self);
 
-JoggResult *jogg_result_new (GDesktopAppInfo *);
+GtkOrdering jogg_result_compare ( const JoggResult *lhs
+                                , const JoggResult *rhs);
+
+JoggResult *jogg_result_new ( GDesktopAppInfo *app_info
+                            , const char      *action
+                            , JoggMatchType    match_type
+                            , bool             prefix_match);
 
 G_END_DECLS

--- a/src/jogg-utils.c
+++ b/src/jogg-utils.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
+ */
+
+#include "jogg-utils.h"
+
+#include <glib.h>
+
+bool
+jogg_has_substring ( const char *haystack
+                   , const char *needle
+                   , bool       *prefix_match)
+{
+    g_autofree char *haystack_folded = NULL;
+    g_autofree char *needle_folded = NULL;
+    const char *p = NULL;
+
+    if (NULL == haystack)
+    {
+        return false;
+    }
+    if (NULL == needle)
+    {
+        return false;
+    }
+
+    haystack_folded = g_utf8_casefold (haystack, -1);
+    needle_folded = g_utf8_casefold (needle, -1);
+    p = g_strstr_len (haystack_folded, -1, needle_folded);
+    if (NULL == p)
+    {
+        return false;
+    }
+
+    if (prefix_match != NULL)
+    {
+        *prefix_match = (p == haystack_folded);
+    }
+
+    return true;
+}

--- a/src/jogg-utils.h
+++ b/src/jogg-utils.h
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+bool jogg_has_substring ( const char *haystack
+                        , const char *needle
+                        , bool       *prefix);

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,13 +7,24 @@ jogg_sources = [
     source_dir: 'res',
     c_name: 'jogg'
   ),
+  gnome.mkenums(
+    'jogg-enum-types',
+    c_template: 'jogg-enum-types.c.template',
+    h_template: 'jogg-enum-types.h.template',
+    sources: [
+      'jogg-enums.h',
+    ],
+  ),
   'jogg-application.c',
   'jogg-application.h',
   'jogg-application-window.c',
   'jogg-application-window.h',
+  'jogg-enums.h',
   'jogg-result.c',
   'jogg-result.h',
   'jogg-types.h',
+  'jogg-utils.c',
+  'jogg-utils.h',
   'main.c',
 ]
 
@@ -22,8 +33,10 @@ executable('jogg',
   dependencies: [
     gio_unix,
     glib,
+    gmodule_export,
     gtk4_layer_shell,
     gtk4,
   ],
+  export_dynamic: true,
   install: true,
 )

--- a/src/res/ui/result.ui
+++ b/src/res/ui/result.ui
@@ -21,12 +21,46 @@
           </object>
         </child>
         <child>
-          <object class='GtkLabel'>
-            <binding name='label'>
-              <lookup name='label' type='JoggResult'>
-                <lookup name='item'>GtkListItem</lookup>
-              </lookup>
-            </binding>
+          <object class='GtkBox'>
+            <property name='orientation'>horizontal</property>
+            <property name='spacing'>6</property>
+            <child>
+              <object class='GtkLabel'>
+                <binding name='label'>
+                  <lookup name='label' type='JoggResult'>
+                    <lookup name='item'>GtkListItem</lookup>
+                  </lookup>
+                </binding>
+              </object>
+            </child>
+            <child>
+              <object class='GtkBox'>
+                <property name='orientation'>horizontal</property>
+                <property name='spacing'>6</property>
+                <binding name='visible'>
+                  <closure type='gboolean' function='jogg_result_is_action_visible'>
+                    <lookup name='item'>GtkListItem</lookup>
+                  </closure>
+                </binding>
+                <style>
+                  <class name='dim-label'/>
+                </style>
+                <child>
+                  <object class='GtkImage'>
+                    <property name='icon-name'>pan-end-symbolic</property>
+                  </object>
+                </child>
+                <child>
+                  <object class='GtkLabel'>
+                    <binding name='label'>
+                      <lookup name='action' type='JoggResult'>
+                        <lookup name='item'>GtkListItem</lookup>
+                      </lookup>
+                    </binding>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/res/ui/window.ui
+++ b/src/res/ui/window.ui
@@ -44,14 +44,38 @@
                           <property name='model'>
                             <object class='GtkSingleSelection' id='model'>
                               <property name='model'>
-                                <object class="GtkFilterListModel" id='filter_model'>
+                                <object class='GtkSortListModel' id='sort_model'>
                                   <property name='model'>
-                                    <object class='GListStore' id='applications'>
-                                      <property name='item-type'>JoggResult</property>
+                                    <object class='GtkFilterListModel' id='filter_model'>
+                                      <property name='model'>
+                                        <object class='GListStore' id='applications'>
+                                          <property name='item-type'>JoggResult</property>
+                                        </object>
+                                      </property>
+                                      <property name='filter'>
+                                        <object class='GtkBoolFilter'>
+                                          <property name='expression'>
+                                            <lookup name='hidden' type='JoggResult'/>
+                                          </property>
+                                          <property name='invert'>true</property>
+                                        </object>
+                                      </property>
                                     </object>
                                   </property>
-                                  <property name='filter'>
-                                    <object class='GtkCustomFilter' id='filter'/>
+                                  <property name='sorter'>
+                                    <object class='GtkMultiSorter'>
+                                      <child>
+                                        <object class='GtkCustomSorter' id='custom_sorter'/>
+                                      </child>
+                                      <child>
+                                        <object class='GtkNumericSorter'>
+                                          <property name='expression'>
+                                            <lookup name='prefix-match' type='JoggResult'/>
+                                          </property>
+                                          <property name='sort-order'>descending</property>
+                                        </object>
+                                      </child>
+                                    </object>
                                   </property>
                                 </object>
                               </property>


### PR DESCRIPTION
This commit ditches g_desktop_app_info_search() with a modified copy of the search code in order to support searching for actions in desktop entries. That additionally required implementing own sorting, which currently is based on the specificity of the match type (e.g. name ranks above display name and keywords and so on) and whether we’ve prefix-matched.

Resolves #5.