### PR TITLE
Show desktop entry descriptions in results

### DIFF
--- a/src/jogg-application-window.c
+++ b/src/jogg-application-window.c
@@ -32,10 +32,11 @@ G_DEFINE_TYPE ( JoggApplicationWindow
               );
 
 static gboolean
-jogg_application_window_transform_n_items (GBinding     *binding,
-                                           const GValue *from_value,
-                                           GValue       *to_value,
-                                           gpointer      user_data)
+jogg_application_window_transform_n_items ( GBinding     *binding
+                                          , const GValue *from_value
+                                          , GValue       *to_value
+                                          , gpointer      user_data
+                                          )
 {
     guint n_items;
 
@@ -47,9 +48,10 @@ jogg_application_window_transform_n_items (GBinding     *binding,
 }
 
 static void
-jogg_application_window_results_revealer_on_notify_reveal_child (GObject    *self,
-                                                                   GParamSpec *pspec,
-                                                                   gpointer    user_data)
+jogg_application_window_results_revealer_on_notify_reveal_child ( GObject    *self
+                                                                , GParamSpec *pspec
+                                                                , gpointer    user_data
+                                                                )
 {
     JoggApplicationWindow *window;
 
@@ -62,9 +64,10 @@ jogg_application_window_results_revealer_on_notify_reveal_child (GObject    *sel
 }
 
 static void
-jogg_application_window_results_revealer_on_notify_child_revealed (GObject    *self,
-                                                                   GParamSpec *pspec,
-                                                                   gpointer    user_data)
+jogg_application_window_results_revealer_on_notify_child_revealed ( GObject    *self
+                                                                  , GParamSpec *pspec
+                                                                  , gpointer    user_data
+                                                                  )
 {
     JoggApplicationWindow *window;
 
@@ -104,8 +107,9 @@ jogg_application_window_search_entry_on_activate ( GtkSearchEntry *self
 }
 
 static void
-jogg_application_window_search_entry_on_search_changed (GtkSearchEntry *self,
-                                                        gpointer        user_data)
+jogg_application_window_search_entry_on_search_changed ( GtkSearchEntry *self
+                                                       , gpointer        user_data
+                                                       )
 {
     JoggApplicationWindow *window = NULL;
     size_t n = 0;
@@ -129,9 +133,10 @@ jogg_application_window_search_entry_on_search_changed (GtkSearchEntry *self,
 }
 
 static void
-jogg_application_window_revealer_on_child_revealed (GObject    *self,
-                                                    GParamSpec *pspec,
-                                                    gpointer    user_data)
+jogg_application_window_revealer_on_child_revealed ( GObject    *self
+                                                   , GParamSpec *pspec
+                                                   , gpointer    user_data
+                                                   )
 {
     (void) pspec;
 
@@ -163,7 +168,8 @@ jogg_application_window_quit (JoggApplicationWindow *self)
 
 static void
 jogg_application_window_search_entry_on_stop_search ( GtkSearchEntry *self
-                                                    , gpointer        user_data)
+                                                    , gpointer        user_data
+                                                    )
 {
     jogg_application_window_quit (JOGG_APPLICATION_WINDOW (user_data));
 }
@@ -171,7 +177,8 @@ jogg_application_window_search_entry_on_stop_search ( GtkSearchEntry *self
 static void
 jogg_application_window_results_on_activate ( GtkListView *self
                                             , guint        position
-                                            , gpointer     user_data)
+                                            , gpointer     user_data
+                                            )
 {
     GtkSelectionModel *model = NULL;
     JoggResult *item = NULL;
@@ -198,7 +205,8 @@ jogg_application_window_results_on_activate ( GtkListView *self
 static gint
 jogg_application_window_result_sort_func ( gconstpointer a
                                          , gconstpointer b
-                                         , gpointer      user_data)
+                                         , gpointer      user_data
+                                         )
 {
     return jogg_result_compare (a, b);
 }
@@ -355,9 +363,10 @@ jogg_application_window_map (GtkWidget *self)
 }
 
 static gboolean
-jogg_application_window_on_escape_pressed (GtkWidget *widget,
-                                           GVariant  *args,
-                                           gpointer   user_data)
+jogg_application_window_on_escape_pressed ( GtkWidget *widget
+                                          , GVariant  *args
+                                          , gpointer   user_data
+                                          )
 {
     jogg_application_window_quit (JOGG_APPLICATION_WINDOW (widget));
 
@@ -389,33 +398,42 @@ jogg_application_window_class_init (JoggApplicationWindowClass *klass)
                                          , JoggApplicationWindow
                                          , model
                                          );
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          filter_model);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          applications);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          custom_sorter);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          revealer);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          revealer_box);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          search_entry);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          results_revealer);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          results_scrolled_window);
-    gtk_widget_class_bind_template_child (widget_class,
-                                          JoggApplicationWindow,
-                                          results);
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , filter_model
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , applications
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , custom_sorter
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , revealer
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , revealer_box
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , search_entry
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , results_revealer
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , results_scrolled_window
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggApplicationWindow
+                                         , results
+                                         );
 
     gtk_widget_class_bind_template_callback (widget_class,
                                              jogg_application_window_search_entry_on_search_changed);
@@ -426,7 +444,8 @@ jogg_application_window_class_init (JoggApplicationWindowClass *klass)
 JoggApplicationWindow *
 jogg_application_window_new (JoggApplication *app)
 {
-      return g_object_new (JOGG_TYPE_APPLICATION_WINDOW,
-                           "application", app,
-                           NULL);
+      return g_object_new ( JOGG_TYPE_APPLICATION_WINDOW
+                          , "application" , app
+                          , NULL
+                          );
 }

--- a/src/jogg-application-window.c
+++ b/src/jogg-application-window.c
@@ -297,13 +297,6 @@ jogg_application_window_init (JoggApplicationWindow *self)
                      , G_CALLBACK (jogg_application_window_search_entry_on_activate)
                      , self
                      );
-#if 0
-    g_signal_connect ( self->search_entry
-                     , "next-match"
-                     , G_CALLBACK (jogg_application_window_search_entry_on_next_match)
-                     , self
-                     );
-#endif
     g_signal_connect ( self->search_entry
                      , "search-changed"
                      , G_CALLBACK (jogg_application_window_search_entry_on_search_changed)
@@ -434,11 +427,6 @@ jogg_application_window_class_init (JoggApplicationWindowClass *klass)
                                          , JoggApplicationWindow
                                          , results
                                          );
-
-    gtk_widget_class_bind_template_callback (widget_class,
-                                             jogg_application_window_search_entry_on_search_changed);
-    gtk_widget_class_bind_template_callback (widget_class,
-                                             jogg_application_window_search_entry_on_stop_search);
 }
 
 JoggApplicationWindow *

--- a/src/jogg-application.c
+++ b/src/jogg-application.c
@@ -194,8 +194,8 @@ match_found:
 JoggApplication *
 jogg_application_new (void)
 {
-      return g_object_new (JOGG_TYPE_APPLICATION,
-                           "application-id", "engineering.baltic.jogg",
-                           "flags", G_APPLICATION_DEFAULT_FLAGS,
-                           NULL);
+      return g_object_new ( JOGG_TYPE_APPLICATION
+                          , "application-id", "engineering.baltic.jogg"
+                          , "flags", G_APPLICATION_DEFAULT_FLAGS
+                          , NULL);
 }

--- a/src/jogg-result-widget.c
+++ b/src/jogg-result-widget.c
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
+ */
+
+#include "jogg-result.h"
+#include "jogg-result-widget.h"
+
+struct _JoggResultWidget
+{
+    GtkBox parent_instance;
+
+    JoggResult *result;
+
+    GtkWidget *icon;
+    GtkWidget *name_description_box;
+    GtkWidget *name;
+    GtkWidget *action_box;
+    GtkWidget *action;
+    GtkWidget *description;
+};
+
+G_DEFINE_TYPE (JoggResultWidget, jogg_result_widget, GTK_TYPE_BOX);
+
+static void
+jogg_result_widget_init (JoggResultWidget *self)
+{
+    gtk_widget_init_template (GTK_WIDGET (self));
+}
+
+static void
+jogg_result_widget_class_init (JoggResultWidgetClass *klass)
+{
+    GtkWidgetClass *widget_class = NULL;
+
+    widget_class = GTK_WIDGET_CLASS (klass);
+
+    gtk_widget_class_set_template_from_resource ( widget_class
+                                                , "/baltic/engineering/jogg/ui/result.ui"
+                                                );
+
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggResultWidget
+                                         , icon
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggResultWidget
+                                         , name_description_box
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggResultWidget
+                                         , name
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggResultWidget
+                                         , action_box
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggResultWidget
+                                         , action
+                                         );
+    gtk_widget_class_bind_template_child ( widget_class
+                                         , JoggResultWidget
+                                         , description
+                                         );
+}
+
+void
+jogg_result_widget_set_result ( JoggResultWidget *self
+                              , JoggResult       *result
+                              )
+{
+    GDesktopAppInfo *app_info = NULL;
+    GIcon *icon = NULL;
+    const char *name = NULL;
+    g_autofree char *action = NULL;
+    g_autofree char *action_name = NULL;
+    const char *description = NULL;
+
+    g_return_if_fail (JOGG_IS_RESULT_WIDGET (self));
+    g_return_if_fail (JOGG_IS_RESULT (result));
+
+    app_info = jogg_result_get_app_info (result);
+    icon = g_app_info_get_icon (G_APP_INFO (app_info));
+    if (NULL == icon)
+    {
+        icon = g_icon_new_for_string ("application-x-executable", NULL);
+    }
+    else
+    {
+        icon = g_object_ref (icon);
+    }
+    name = g_app_info_get_name (G_APP_INFO (app_info));
+    action = jogg_result_get_action (result);
+    if (action != NULL)
+    {
+        action_name = g_desktop_app_info_get_action_name (app_info, action);
+    }
+    description = g_app_info_get_description (G_APP_INFO (app_info));
+
+    gtk_image_set_from_gicon (GTK_IMAGE (self->icon), icon);
+    gtk_label_set_label (GTK_LABEL (self->name), name);
+    gtk_label_set_label (GTK_LABEL (self->action), action_name);
+    gtk_label_set_label (GTK_LABEL (self->description), description);
+
+    gtk_widget_set_visible (self->action_box, action != NULL);
+    gtk_widget_set_visible (self->description, description != NULL);
+}
+
+GtkWidget *
+jogg_result_widget_new (void)
+{
+    return g_object_new (JOGG_TYPE_RESULT_WIDGET, NULL);
+}

--- a/src/jogg-result-widget.h
+++ b/src/jogg-result-widget.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * Copyright (C) 2024 Ernestas Kulik <ernestas AT baltic DOT engineering>
+ */
+
+#pragma once
+
+#include "jogg-types.h"
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE ( JoggResultWidget
+                     , jogg_result_widget
+                     , JOGG
+                     , RESULT_WIDGET
+                     , GtkBox
+                     );
+
+void jogg_result_widget_set_result     ( JoggResultWidget *self
+                                       , JoggResult       *result
+                                       );
+
+GtkWidget *jogg_result_widget_new (void);
+
+G_END_DECLS

--- a/src/jogg-result.c
+++ b/src/jogg-result.c
@@ -30,46 +30,6 @@ static GParamSpec *properties[N_PROPERTIES];
 
 G_DEFINE_TYPE (JoggResult, jogg_result, G_TYPE_OBJECT);
 
-char *
-jogg_result_get_action_name ( GObject    *object
-                            , JoggResult *self)
-{
-    if (NULL == self)
-    {
-        return NULL;
-    }
-    if (NULL == self->action)
-    {
-        return NULL;
-    }
-
-    return g_desktop_app_info_get_action_name (self->app_info, self->action);
-}
-
-GIcon *
-jogg_result_get_icon ( GObject    *object
-                     , JoggResult *self)
-{
-    GIcon *icon = NULL;
-
-    if (NULL == self)
-    {
-        return NULL;
-    }
-
-    icon = g_app_info_get_icon (G_APP_INFO (self->app_info));
-    if (NULL == icon)
-    {
-        icon = g_icon_new_for_string ("application-x-executable", NULL);
-    }
-    else
-    {
-        icon = g_object_ref (icon);
-    }
-
-    return icon;
-}
-
 gboolean
 jogg_result_is_action_visible ( GObject    *object
                               , JoggResult *self)

--- a/src/jogg-types.h
+++ b/src/jogg-types.h
@@ -11,11 +11,13 @@
 #define JOGG_TYPE_APPLICATION jogg_application_get_type ()
 #define JOGG_TYPE_APPLICATION_WINDOW jogg_application_window_get_type ()
 #define JOGG_TYPE_RESULT jogg_result_get_type ()
+#define JOGG_TYPE_RESULT_WIDGET jogg_result_widget_get_type ()
 
 G_BEGIN_DECLS
 
 typedef struct _JoggApplication JoggApplication;
 typedef struct _JoggApplicationWindow JoggApplicationWindow;
 typedef struct _JoggResult JoggResult;
+typedef struct _JoggResultWidget JoggResultWidget;
 
 G_END_DECLS

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,8 @@ jogg_sources = [
   'jogg-enums.h',
   'jogg-result.c',
   'jogg-result.h',
+  'jogg-result-widget.c',
+  'jogg-result-widget.h',
   'jogg-types.h',
   'jogg-utils.c',
   'jogg-utils.h',

--- a/src/res/ui/result.ui
+++ b/src/res/ui/result.ui
@@ -1,47 +1,36 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <interface>
   <requires lib='gtk' version='4.0'/>
-  <template class='GtkListItem'>
-    <property name='child'>
-      <object class='GtkBox'>
-        <property name='margin-bottom'>6</property>
-        <property name='margin-end'>6</property>
-        <property name='margin-start'>6</property>
-        <property name='margin-top'>6</property>
-        <property name='orientation'>horizontal</property>
-        <property name='spacing'>12</property>
-        <child>
-          <object class='GtkImage'>
-            <binding name='gicon'>
-              <closure type='GIcon' function='jogg_result_get_icon'>
-                <lookup name='item'>GtkListItem</lookup>
-              </closure>
-            </binding>
-            <property name='icon-size'>large</property>
-          </object>
-        </child>
+  <template class='JoggResultWidget' parent='GtkBox'>
+    <property name='margin-bottom'>6</property>
+    <property name='margin-end'>6</property>
+    <property name='margin-start'>6</property>
+    <property name='margin-top'>6</property>
+    <property name='orientation'>horizontal</property>
+    <property name='spacing'>12</property>
+    <child>
+      <object class='GtkImage' id='icon'>
+        <property name='icon-size'>large</property>
+      </object>
+    </child>
+    <child>
+      <object class='GtkBox' id='name_description_box'>
+        <property name='orientation'>vertical</property>
+        <property name='spacing'>6</property>
+        <property name='valign'>center</property>
         <child>
           <object class='GtkBox'>
+            <property name='halign'>start</property>
             <property name='orientation'>horizontal</property>
             <property name='spacing'>6</property>
             <child>
-              <object class='GtkLabel'>
-                <binding name='label'>
-                  <lookup name='label' type='JoggResult'>
-                    <lookup name='item'>GtkListItem</lookup>
-                  </lookup>
-                </binding>
-              </object>
+              <object class='GtkLabel' id='name'/>
             </child>
             <child>
-              <object class='GtkBox'>
+              <object class='GtkBox' id='action_box'>
                 <property name='orientation'>horizontal</property>
                 <property name='spacing'>6</property>
-                <binding name='visible'>
-                  <closure type='gboolean' function='jogg_result_is_action_visible'>
-                    <lookup name='item'>GtkListItem</lookup>
-                  </closure>
-                </binding>
+                <property name='visible'>false</property>
                 <style>
                   <class name='dim-label'/>
                 </style>
@@ -51,20 +40,25 @@
                   </object>
                 </child>
                 <child>
-                  <object class='GtkLabel'>
-                    <binding name='label'>
-                      <closure type='gchararray' function='jogg_result_get_action_name'>
-                        <lookup name='item'>GtkListItem</lookup>
-                      </closure>
-                    </binding>
-                  </object>
+                  <object class='GtkLabel' id='action'/>
                 </child>
               </object>
             </child>
           </object>
         </child>
+        <child>
+          <object class='GtkLabel' id='description'>
+            <attributes>
+              <attribute name='style' value='italic'/>
+            </attributes>
+            <property name='halign'>start</property>
+            <style>
+              <class name='caption'/>
+              <class name='dim-label'/>
+            </style>
+          </object>
+        </child>
       </object>
-    </property>
-    <property name='focusable'>false</property>
+    </child>
   </template>
 </interface>

--- a/src/res/ui/window.ui
+++ b/src/res/ui/window.ui
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <interface>
   <requires lib='gtk' version='4.0'/>
+  <object class='GtkSizeGroup' id='size_group'>
+    <property name='mode'>vertical</property>
+  </object>
   <template class='JoggApplicationWindow' parent='GtkApplicationWindow'>
     <property name='focus-widget'>search_entry</property>
     <property name='resizable'>false</property>
@@ -36,8 +39,7 @@
                       <child>
                         <object class='GtkListView' id='results'>
                           <property name='factory'>
-                            <object class='GtkBuilderListItemFactory'>
-                              <property name='resource'>/baltic/engineering/jogg/ui/result.ui</property>
+                            <object class='GtkSignalListItemFactory' id='list_item_factory'>
                             </object>
                           </property>
                           <property name='focusable'>false</property>


### PR DESCRIPTION
Probably not necessary, but this commit creates a new widget for
results, allowing better reuse of widgets and controlling their vertical
size, which is required to not have different size results when not all
desktop entries have descriptions.

Resolves https://github.com/ernestask/jogg/issues/6